### PR TITLE
Fix bug: enumerate all Windows HID devices

### DIFF
--- a/src/purejavahidapi/windows/WindowsBackend.java
+++ b/src/purejavahidapi/windows/WindowsBackend.java
@@ -173,7 +173,7 @@ public class WindowsBackend extends Backend {
 					// recreate as above when opening the device
 					devHandle = openDeviceHandle(path, true);
 					if (devHandle == INVALID_HANDLE_VALUE)
-						break;
+						continue;
 
 					HIDD_ATTRIBUTES attrib = new HIDD_ATTRIBUTES();
 					attrib.Size = new NativeLong(attrib.size());


### PR DESCRIPTION
Thanks for publishing purejavahidapi to Maven! It's been really helpful. I found a bug where the Windows backend wouldn't enumerate all HID devices. Please see the attached commit for a bug fix.

---

WindowsBackend.enumerateDevices() stops enumerating after a device fails to open. It should continue enumerating the other remaining devices. See original behavior in hidapi. https://github.com/signal11/hidapi/blob/hidapi-0.8.0-rc1/windows/hid.c#L371